### PR TITLE
fix note connection names to not include self

### DIFF
--- a/frontend/src/components/notes/note_connect_container.js
+++ b/frontend/src/components/notes/note_connect_container.js
@@ -10,7 +10,8 @@ const mapStateToProps = (state, ownProps) => {
         _id: state.ui.modal.action.boardId,
         boardId: ownProps.location.pathname,
         notes: state.entities.notes,
-        connections: state.entities.connections
+        connections: state.entities.connections,
+        noteTitle: state.ui.modal.action.title
     }
 }
 

--- a/frontend/src/components/notes/note_connector.js
+++ b/frontend/src/components/notes/note_connector.js
@@ -18,8 +18,8 @@ class NoteConnector extends React.Component {
         connList = Object.values(connList);
         let buttons = []
         for (let [key, value] of Object.entries(connList)) {
-            let name = this.findNoteName(value.note2)
             if (value.note1 === this.props._id || value.note2 === this.props._id) {
+                let name = this.findNoteName(value.note2) === this.props.noteTitle ? this.findNoteName(value.note1) : this.findNoteName(value.note2);
                 buttons.push(<button onClick={() => this.props.deleteConnection(value._id)}>{name}</button>)
             }
         }


### PR DESCRIPTION
When removing note connections, some of the options included itself which didn't make sense. I fixed that so removal options only included other connected notes.
Eazy money