### PR TITLE
Delete connections with note

### DIFF
--- a/frontend/src/actions/note_actions.js
+++ b/frontend/src/actions/note_actions.js
@@ -22,9 +22,9 @@ export const receiveNote = note => ({
     note
 })
 
-export const removeNote = noteId => ({
+export const removeNote = pojo => ({
     type: REMOVE_NOTE,
-    noteId
+    pojo
 })
 
 export const receiveErrors = errors => ({
@@ -67,6 +67,6 @@ export const updateNote = data => dispatch => {
 
 export const eraseNote = noteId => dispatch => (
     deleteNote(noteId)
-        .then(note => dispatch(removeNote(note)))
+        .then(pojo => dispatch(removeNote(pojo)))
         .catch(err => console.log(err))
 )

--- a/frontend/src/reducers/connections_reducer.js
+++ b/frontend/src/reducers/connections_reducer.js
@@ -1,4 +1,5 @@
 import { RECEIVE_CONNECTIONS, RECEIVE_CONNECTION, REMOVE_CONNECTION } from '../actions/connection_actions';
+import { REMOVE_NOTE } from '../actions/note_actions';
 import { arrayToObject } from './selectors';
 
 const ConnectionsReducer = (state = {}, action) => {
@@ -14,6 +15,12 @@ const ConnectionsReducer = (state = {}, action) => {
       return nextState
     case REMOVE_CONNECTION:
       delete nextState[action.connectionId.data._id];
+      return nextState;
+    case REMOVE_NOTE:
+      console.log(action.pojo);
+      action.pojo.data.connectionIds.forEach(connId => {
+        delete nextState[connId];
+      })
       return nextState;
     default: {
       return state;

--- a/frontend/src/reducers/notes_reducer.js
+++ b/frontend/src/reducers/notes_reducer.js
@@ -18,7 +18,7 @@ const NotesReducer = (state = {}, action) => {
         case RECEIVE_NOTE:
             return Object.assign(newState, { [action.note.data._id]: action.note.data })
         case REMOVE_NOTE:
-            delete newState[action.noteId.data._id];
+            delete newState[action.pojo.data.noteId];
             return newState;
         case RECEIVE_BOARD: 
             return Object.assign(newState, action.payload.data.notes)

--- a/routes/api/notes.js
+++ b/routes/api/notes.js
@@ -68,15 +68,35 @@ router.get("/board/:board_id",
       .catch(err => res.json(err))
 })
 
-router.delete("/:note_id", 
+router.delete("/:note_id",
   passport.authenticate("jwt", { session: false }),
   (req, res) => {
+    let response = {};
+    response['connectionIds'] = [];
+
+    Connection.find({ note1: req.params.note_id })
+      .then(connections => {
+        connections.forEach(conn => {
+          response['connectionIds'].push(conn.id);
+        })
+      })
+    Connection.find({ note2: req.params.note_id })
+      .then(connections => {
+        connections.forEach(conn => {
+          response['connectionIds'].push(conn.id);
+        })
+      })
+
     Connection.deleteMany({ note1: req.params.note_id }).exec()
     Connection.deleteMany({ note2: req.params.note_id }).exec()
-    
+
     Note.findByIdAndDelete(req.params.note_id)
-        .then((note) => res.json(note))
-        .catch(err => res.json(err))
+      .then((note) => {
+        response['noteId'] = note.id
+        console.log(response);
+        res.json(response);
+      })
+      .catch(err => res.json(err))
 })
 
 module.exports = router;


### PR DESCRIPTION
Now connections are removed on the frontend too when a note is deleted. Before it would error out when a note was deleted that had existing connections.